### PR TITLE
Fix Benchmarks

### DIFF
--- a/benchmarks/messaging.rb
+++ b/benchmarks/messaging.rb
@@ -10,7 +10,7 @@ require 'dcell'
 DCell.setup
 DCell.run!
 
-RECEIVER_PORT = 12345
+RECEIVER_PORT = 2043
 
 $receiver_pid = Process.spawn Gem.ruby, File.expand_path("../receiver.rb", __FILE__)
 STDERR.print "Waiting for test node to start up..."
@@ -51,6 +51,12 @@ class AsyncPerformanceTest
     signal :complete
   end
 end
+
+DCell.start :id => "messaging_node", :addr => "tcp://127.0.0.1:2042",
+  :directory => {
+    :id => "benchmark_receiver",
+    :addr => "tcp://127.0.0.1:#{RECEIVER_PORT}"
+  }
 
 receiver = DCell::Node['benchmark_receiver']
 progenator = receiver[:progenator]

--- a/benchmarks/receiver.rb
+++ b/benchmarks/receiver.rb
@@ -3,7 +3,7 @@ require 'bundler'
 Bundler.setup
 
 require 'dcell'
-DCell.setup :id => 'benchmark_receiver', :addr => 'tcp://127.0.0.1:12345'
+DCell.start :id => 'benchmark_receiver', :addr => 'tcp://127.0.0.1:2043'
 
 class AsyncReceiver
   include Celluloid


### PR DESCRIPTION
I had some issues getting the benchmarks working out of the box.  These changes make them behave better, and more closely match the examples on the wiki.  

I'm still not happy with the receiver termination (kill 9 isn't super graceful), but since these are benchmarks I suppose that doesn't matter.
