### PR TITLE
Dcell on Heroku and `lsb_release -d` causes catastrophic failure

### DIFF
--- a/lib/dcell/info_service.rb
+++ b/lib/dcell/info_service.rb
@@ -45,7 +45,7 @@ module DCell
 
         cores = cpu_info.scan(/core id\s+: \d+/).uniq.size
         @cpu_count = cores > 0 ? cores : 1
-        @distribution = `lsb_release -d`[/Description:\s+(.*)\s*$/, 1]
+        @distribution = discover_distribution
       else
         @cpu_type = @cpu_vendor = @cpu_speed = @cpu_count = nil
       end
@@ -88,6 +88,11 @@ module DCell
       uptime = matches[1]
       days_string = uptime[/^(\d+) days/, 1]
       days_string ? Integer(days_string) : 0
+    end
+
+    def discover_distribution
+      `lsb_release -d`[/Description:\s+(.*)\s*$/, 1]
+    rescue Errno::ENOENT
     end
 
     def to_hash


### PR DESCRIPTION
I have forked a copy of the ffi-rzmq gem and added in some Heroku (via bash) compiled zeromq libraries:

https://github.com/jsgoecke/ffi-rzmq/commit/ae88b6bc8f5b6f28017385777068a2c206065b37

But when I try to kick off the process on Heroku I am getting an error from this line:

https://github.com/celluloid/dcell/blob/master/lib/dcell/info_service.rb#L48

Here is the error itself:

https://gist.github.com/73cdfcd534700f073af2

This causes a catastrophic failure of the application. Would be great if it gave a warning instead.
