### PR TITLE
added timeout for the discovery of cells within a node 

### DIFF
--- a/lib/dcell/node.rb
+++ b/lib/dcell/node.rb
@@ -7,6 +7,8 @@ module DCell
 
     finalizer :shutdown
 
+    NODE_DISCOVERY_TIMEOUT = 5
+
     # FSM
     default_state :disconnected
     state :shutdown
@@ -70,10 +72,11 @@ module DCell
       request = Message::Find.new(Thread.mailbox, name)
       send_message request
 
-      response = receive do |msg|
+      response = receive(NODE_DISCOVERY_TIMEOUT) do |msg|
         msg.respond_to?(:request_id) && msg.request_id == request.id
       end
 
+      return nil if response.nil?
       abort response.value if response.is_a? ErrorResponse
       response.value
     end


### PR DESCRIPTION
Added a default timeout for discovering cells within a node. 

This was the stated issue https://github.com/celluloid/dcell/issues/64 .

Some things to review: 
- consistency of returning nil on timeout. I think it is, since when we try to find an unexistent cell within a node, it also returns nil. 
- SIGTERM handling. The process sends the terminate signal to the actors, but one of them hangs on some :zmqwait message. And then I have to kill. I thought timeout on the receive would discard the message, but apparently it doesn't. Or is this an issue that has been resolved already on celluloid master branch (future 0.16)?
