### PR TITLE
move alias method below method definition to fix undef method error

### DIFF
--- a/lib/dcell/celluloid_ext.rb
+++ b/lib/dcell/celluloid_ext.rb
@@ -13,12 +13,12 @@ module Celluloid
     # Marshal uses respond_to? to determine if this object supports _dump so
     # unfortunately we have to monkeypatch in _dump support as the proxy
     # itself normally jacks respond_to? and proxies to the actor
-    alias_method :__respond_to?, :respond_to?
     def respond_to?(meth, check_private = false)
       return false if meth == :marshal_dump
       return true  if meth == :_dump
       __respond_to?(meth, check_private)
     end
+    alias_method :__respond_to?, :respond_to?
 
     # Dump an actor proxy via its mailbox
     def _dump(level)


### PR DESCRIPTION
Fixes #56

Moved alias_method below the method being aliased to fix NameError: undefined method 'respond_to?' for class 'Celluloid::ActorProxy'

If you run the examples without this fix you will see the above error.
