### PR TITLE
dcell-next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
   - ruby-head
   - jruby
-  - jruby-head
   - rbx-2.2.10
 
 matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,16 @@ Dir["tasks/**/*.rb"].each { |task| load task }
 
 Coveralls::RakeTask.new
 
-task :default => [:clean, 'testnode:bg', :spec, 'testnode:finish', 'coveralls:push']
+task :default do
+  res = 0
+  [:clean, 'testnode:bg', :spec, 'testnode:finish', 'coveralls:push'].each do |tsk|
+    if tsk == :spec
+      sh "rake spec" do |r|
+        res = 1 unless r
+      end
+    else
+      Rake::Task[tsk].invoke
+    end
+  end
+  exit res
+end

--- a/examples/itchy-launcher.rb
+++ b/examples/itchy-launcher.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+pids = Array.new
+count = 1
+threaded = false
+mass = false
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: itchy-launcher.rb [options]"
+
+  opts.on("--count COUNT", OptionParser::DecimalInteger, "Number of itchy instances") do |v|
+    count = v
+  end
+  opts.on("--threaded", "Start itchy with many actors") do
+    threaded = true
+  end
+  opts.on("--mass", "Start many itchies with many actors") do
+    mass = true
+  end
+end.parse!
+
+Signal.trap(:INT) do
+  pids.each do |pid|
+    begin
+      Process.kill :TERM, pid if pid
+    rescue
+    end
+  end
+end
+
+def spawn_itchy(pids, args)
+  pid = Process.spawn Gem.ruby, File.expand_path("./examples/itchy.rb"), *args
+  unless pid
+    STDERR.print "ERROR: Couldn't start test node."
+  end
+  pids << pid
+end
+
+if threaded and not mass
+  spawn_itchy pids, ["--count", "#{count}"]
+else
+  count.times do |id|
+    pargs = ["--id", "itchy-#{Process.pid}-#{id}"]
+    pargs += ["--count", "#{count}"] if threaded
+    spawn_itchy pids, pargs
+  end
+end
+
+Process.waitall

--- a/examples/itchy.rb
+++ b/examples/itchy.rb
@@ -1,14 +1,20 @@
 #!/usr/bin/env ruby
-require 'dcell'
 
-DCell.start :id => "itchy"
+require 'dcell'
+require 'optparse'
+require_relative 'registry'
+
+id = 'itchy'
 
 class Itchy
   include Celluloid
 
+  attr_accessor :res, :n
+
   def initialize
     puts "Ready for mayhem!"
     @n = 0
+    @res = 0
   end
 
   def fight
@@ -20,7 +26,41 @@ class Itchy
     end
     @n
   end
+
+  def work(value)
+    @n += 1
+    res = 0
+    100000.times do
+      res += (value + 1) ** 2
+    end
+    @res += res
+    res
+  end
 end
 
-Itchy.supervise_as :itchy
-sleep
+if __FILE__ == $0
+  count = 1
+  OptionParser.new do |opts|
+    opts.banner = "Usage: itchy.rb [options]"
+
+    opts.on("--id ID", "Assign node ID") do |v|
+      id = v
+    end
+    opts.on("--count COUNT", OptionParser::DecimalInteger, "Number of itchy actors") do |v|
+      count = v
+    end
+  end.parse!
+
+  if count == 1
+    Itchy.supervise_as :itchy
+    puts "Starting :itchy with ID '#{id}'"
+  else
+    count.times do |idx|
+      name = "itchy-#{idx}".to_sym
+      Itchy.supervise_as name
+      puts "Starting #{name} with ID '#{id}'"
+    end
+  end
+  DCell.start :id =>id, :registry => registry
+  sleep
+end

--- a/examples/massive-scratchy.rb
+++ b/examples/massive-scratchy.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+require 'dcell'
+require_relative 'registry'
+require_relative 'itchy'
+require 'optparse'
+
+local = true
+actor = :itchy
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: massive-scratchy.rb [options]"
+
+  opts.on("--no-local", "Do not run local celluloid actor tests") do
+    local = false
+  end
+  opts.on("--actor ACTOR", "Actor name to stress") do |a|
+    actor = a.to_sym
+  end
+end.parse!
+
+DCell.start :registry => registry
+puts "Making itchy work hard everywhere!"
+
+def reset(itchies)
+  itchies.each do |itchy|
+    itchy.res = 0
+    itchy.n = 0
+  end
+end
+
+def count(itchies)
+  itchies.reduce(0) {|sum, itchy| sum + itchy.n}
+end
+
+def test_future(itchies, repeat)
+  futures = Array.new
+  barrel = itchies.cycle
+  repeat.times do |i|
+    itchy = barrel.next
+    futures << itchy.future.work(i)
+  end
+  futures.reduce(0) {|sum, f| sum + f.value}
+end
+
+def test_async(itchies, repeat)
+  barrel = itchies.cycle
+  repeat.times do |i|
+    itchy = barrel.next
+    itchy.async.work(i)
+  end
+  itchies.reduce(0) {|sum, itchy| sum + itchy.res}
+end
+
+def run_test(itchies, method, info, args=[])
+  puts "Running test: #{info}"
+  reset itchies
+  start = Time.now
+  res = send "test_#{method}".to_sym, itchies, *args
+  stop = Time.now
+  puts "Test result #{res}, count #{count itchies}"
+  puts "Test executed within #{stop-start}"
+end
+
+Celluloid.logger = nil
+
+max = DCell[actor].count
+repeat = 1000
+
+itchies = DCell[actor]
+run_test itchies, :future, "remote futures", repeat
+run_test itchies, :async, "remote async", repeat
+itchies.each {|itchy| itchy.terminate}
+
+exit unless local
+
+itchies = max.times.map {Itchy.new}
+run_test itchies, :future, "local futures", repeat
+run_test itchies, :async, "local async", repeat
+itchies.each {|itchy| itchy.terminate}
+
+itchies = Itchy.pool size: max
+run_test [itchies], :future, "local futures in pool", repeat
+itchies.terminate

--- a/examples/registry.rb
+++ b/examples/registry.rb
@@ -1,0 +1,4 @@
+require 'dcell/registries/redis_adapter'
+def registry
+  DCell::Registry::RedisAdapter.new :server => 'localhost'
+end

--- a/examples/scratchy-launcher.rb
+++ b/examples/scratchy-launcher.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+pids = Array.new
+count = 1
+indexed = false
+
+args = []
+scratchy = 'scratchy.rb'
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: scratchy-launcher.rb [options]"
+
+  opts.on("--count COUNT", OptionParser::DecimalInteger, "Number of massive-scratchy instances") do |v|
+    count = v
+  end
+  opts.on("--indexed", "Connect to itchy actor with index") do
+    indexed = true
+  end
+  opts.on("--massive", "execute massive scratchy instead of generic") do
+    args = ['--no-local']
+    scratchy = 'massive-scratchy.rb'
+  end
+end.parse!
+
+Signal.trap(:INT) do
+  pids.each do |pid|
+    begin
+      Process.kill :TERM, pid if pid
+    rescue
+    end
+  end
+end
+
+count.times do |id|
+  pargs = args
+  pargs += ["--actor", "itchy-#{id}"] if indexed
+  pid = Process.spawn Gem.ruby, File.expand_path("./examples/#{scratchy}"), *pargs
+  unless pid
+    STDERR.print "ERROR: Couldn't start test node."
+  end
+  pids << pid
+end
+
+start = Time.now
+Process.waitall
+stop = Time.now
+puts "All scratchies completed within #{stop-start} seconds"

--- a/examples/scratchy.rb
+++ b/examples/scratchy.rb
@@ -1,9 +1,22 @@
 #!/usr/bin/env ruby
 require 'dcell'
+require_relative 'registry'
 
-DCell.start
-itchy_node = DCell::Node["itchy"]
-itchy = itchy_node[:itchy]
+DCell.start :registry => registry
+
+def connect(attempts=10)
+  attempts.times do
+    itchy_node = DCell::Node["itchy"]
+    if itchy_node
+      itchy = itchy_node[:itchy]
+      return itchy, itchy_node if itchy
+    end
+    sleep 1
+  end
+  return nil, nil
+end
+
+itchy, itchy_node = connect
 
 puts "All itchy actors: #{itchy_node.all}"
 puts "Fighting itchy! (check itchy's output)"
@@ -16,11 +29,12 @@ puts "Fighting itchy! (check itchy's output)"
     puts itchy.fight
     puts future.value
   rescue Celluloid::DeadActorError
-    puts "Itchy dying?"
-    itchy = itchy_node[:itchy]
-  rescue Celluloid::Task::TerminatedError
-    puts "Itchy is dead =/."
-    break
+    puts "Itchy dying? Attempting to reconnect"
+    itchy, itchy_node = connect
+    unless itchy
+      puts "Itchy is dead =/."
+      break
+    end
   rescue => e
     puts "Unknow error #{e.class} => #{e}"
     break

--- a/lib/dcell/directory.rb
+++ b/lib/dcell/directory.rb
@@ -1,31 +1,74 @@
 module DCell
+  # Node metadata helper
+  class DirectoryMeta
+    attr_reader :id, :address, :actors
+
+    def initialize(id, meta)
+      @id = id
+      if meta
+        @address = meta[:address]
+        @actors = meta[:actors].map {|a| a.to_sym}
+      else
+        @actors = Array.new
+      end
+    end
+
+    def address=(address)
+      @address = address
+      DCell.registry.set_node @id, self
+    end
+
+    def actors=(actors)
+      @actors = actors.map {|a| a.to_sym}
+      DCell.registry.set_node @id, self
+    end
+
+    def add_actor(actor)
+      @actors << actor.to_sym
+      DCell.registry.set_node @id, self
+    end
+    alias_method :<<, :add_actor
+
+    def to_msgpack(pk=nil)
+      {
+        address: @address,
+        actors: @actors,
+      }.to_msgpack(pk)
+    end
+  end
+
   # Directory of nodes connected to the DCell cluster
   module Directory
+    include Enumerable
     extend self
 
-    # Get the URL for a particular Node ID
-    def get(node_id)
-      DCell.registry.get_node node_id
+    # Get the address for a particular Node ID
+    def find(id)
+      meta = DCell.registry.get_node(id)
+      DirectoryMeta.new(id, meta)
     end
-    alias_method :[], :get
-
-    # Set the address of a particular Node ID
-    def set(node_id, addr)
-      DCell.registry.set_node node_id, addr
-    end
-    alias_method :[]=, :set
+    alias_method :[], :find
 
     # List all of the node IDs in the directory
     def all
       DCell.registry.nodes
     end
 
+    # Iterates over all registered nodes
+    def each
+      DCell.registry.nodes.each do |id|
+        yield Directory[id]
+      end
+    end
+
+    # Remove all nodes in the directory
     def clear_all
       DCell.registry.clear_all_nodes
     end
 
-    def remove(node)
-      DCell.registry.remove_node node
+    # Remove information for a give Node ID
+    def remove(id)
+      DCell.registry.remove_node id
     end
   end
 end

--- a/lib/dcell/explorer.rb
+++ b/lib/dcell/explorer.rb
@@ -63,7 +63,7 @@ module DCell
       @node = node
       @info = @node[:info].to_hash
 
-      template = ERB.new File.read(template, :mode => 'rb')
+      template = ERB.new File.read(template, mode: 'rb')
       template.result(binding)
     end
 

--- a/lib/dcell/info_service.rb
+++ b/lib/dcell/info_service.rb
@@ -99,22 +99,22 @@ module DCell
       uptime_string = `uptime`
 
       {
-        :os            => os,
-        :os_version    => os_version,
-        :hostname      => hostname,
-        :platform      => platform,
-        :distribution  => distribution,
-        :ruby_version  => ruby_version,
-        :ruby_engine   => ruby_engine,
-        :ruby_platform => ruby_platform,
-        :load_averages => load_averages(uptime_string),
-        :uptime        => uptime(uptime_string),
-        :cpu => {
-          :arch   => cpu_arch,
-          :type   => cpu_type,
-          :vendor => cpu_vendor,
-          :speed  => cpu_speed,
-          :count  => cpu_count
+        os:            os,
+        os_version:    os_version,
+        hostname:      hostname,
+        platform:      platform,
+        distribution:  distribution,
+        ruby_version:  ruby_version,
+        ruby_engine:   ruby_engine,
+        ruby_platform: ruby_platform,
+        load_averages: load_averages(uptime_string),
+        uptime:        uptime(uptime_string),
+        cpu: {
+          arch:   cpu_arch,
+          type:   cpu_type,
+          vendor: cpu_vendor,
+          speed:  cpu_speed,
+          count:  cpu_count
         }
       }
     end

--- a/lib/dcell/registries/adapter.rb
+++ b/lib/dcell/registries/adapter.rb
@@ -1,0 +1,56 @@
+module DCell
+  module Registry
+    # A DCell registry must implement following methods:
+    # - set(key, value): insert a key->value tuple, overrides previous entry if exists
+    # - get(key): get a value for the key, returns nil if the key is not yet registered
+    # - all: return all registered keys
+    # - remove(key): remove an entry for the key
+    # - clear_all: remove all entries
+    #
+    # DCell requires following independent registry namespaces:
+    #  - node
+    #  - global
+    #
+    # It's up to the registry backend how namespaces are implented(dedicated tables, databases, combinatation of ns:key, etc.)
+
+    module Node
+      def get_node(id)
+        @node_registry.get(id)
+      end
+
+      def set_node(id, meta)
+        @node_registry.set(id, meta)
+      end
+
+      def nodes
+        @node_registry.all
+      end
+
+      def remove_node(id)
+        @node_registry.remove(id)
+      end
+
+      def clear_all_nodes
+        @node_registry.clear_all
+      end
+    end
+
+    module Global
+      def get_global(key)
+        @global_registry.get(key)
+      end
+
+      def set_global(key, value)
+        @global_registry.set(key, value)
+      end
+
+      def global_keys
+        @global_registry.all
+      end
+
+      def clear_globals
+        @global_registry.clear_all
+      end
+    end
+  end
+end

--- a/lib/dcell/registries/errors.rb
+++ b/lib/dcell/registries/errors.rb
@@ -1,0 +1,5 @@
+module DCell
+  module Registry
+    class KeyExists < StandardError; end
+  end
+end

--- a/lib/dcell/registries/mongodb_adapter.rb
+++ b/lib/dcell/registries/mongodb_adapter.rb
@@ -1,8 +1,12 @@
 require 'mongoid'
+require 'bson'
 
 module DCell
   module Registry
     class MongodbAdapter
+      include Node
+      include Global
+
       # Setup connection to mongodb
       # config: path to mongoid configuration file
       # env: mongoid environment to use
@@ -15,71 +19,71 @@ module DCell
         if options[:options]
           Mongoid.options = options[:options]
         end
+
+        @node_registry = Registry.new(DCellNode)
+        @global_registry = Registry.new(DCellGlobal)
       end
 
       class DCellNode
         include Mongoid::Document
 
         field :key, type: String
-        field :value, type: Hash
+        field :value, type: BSON::Binary
       end
 
       class DCellGlobal
         include Mongoid::Document
 
         field :key, type: String
-        field :value, type: Hash
+        field :value, type: BSON::Binary
       end
 
-      class Proxy
-        class << self
-          def set(storage, key, value)
-            entry = storage.find_or_create_by(key: key)
-            entry.value = {'v' => value}
-            entry.save!
-            value
-          end
+      class Registry
+        def initialize(storage)
+          @storage = storage
+        end
 
-          def get(storage, key)
-            first = storage.where(key: key).first
-            if first and first.value
-              return first.value['v']
-            end
-            nil
-          end
+        def _set(key, value, unique)
+          entry = @storage.find_or_create_by(key: key)
+          raise KeyExists if entry.value and unique
+          value = BSON::Binary.new(value.to_msgpack)
+          entry.value = value
+          entry.save!
+          value
+        end
 
-          def all(storage)
-            keys = []
-            storage.each do |entry|
-              keys << entry.key
-            end
-            keys
-          end
+        def set(key, value)
+          _set(key, value, false)
+        end
 
-          def remove(storage, key)
-            begin
-              storage.where(key: key).delete
-            rescue
-            end
+        def get(key)
+          first = @storage.where(key: key).first
+          if first and first.value
+            return MessagePack.unpack(first.value.data,
+                                      options={:symbolize_keys => true})
           end
+          nil
+        end
 
-          def clear_all(storage)
-            storage.delete_all
+        def all
+          keys = []
+          @storage.each do |entry|
+            keys << entry.key
+          end
+          keys
+        end
+
+        def remove(key)
+          begin
+            @storage.where(key: key).delete
+          rescue
           end
         end
+
+        def clear_all
+          @storage.delete_all
+        end
       end
-
-      def get_node(node_id);       Proxy.get(DCellNode, node_id) end
-      def set_node(node_id, addr); Proxy.set(DCellNode, node_id, addr) end
-      def nodes;                   Proxy.all(DCellNode) end
-      def remove_node(node_id);    Proxy.remove(DCellNode, node_id) end
-      def clear_all_nodes;         Proxy.clear_all(DCellNode) end
-
-      def get_global(key);         Proxy.get(DCellGlobal, key) end
-      def set_global(key, value);  Proxy.set(DCellGlobal, key, value) end
-      def global_keys;             Proxy.all(DCellGlobal) end
-      def clear_globals;           Proxy.clear_all(DCellGlobal) end
-
     end
   end
 end

--- a/lib/dcell/registries/redis_adapter.rb
+++ b/lib/dcell/registries/redis_adapter.rb
@@ -5,6 +5,9 @@ require 'redis-namespace'
 module DCell
   module Registry
     class RedisAdapter
+      include Node
+      include Global
+
       def initialize(options)
         # Convert all options to symbols :/
         options = options.inject({}) { |h,(k,v)| h[k.to_sym] = v; h }
@@ -15,81 +18,38 @@ module DCell
         redis  = Redis.new options
         @redis = Redis::Namespace.new @namespace, :redis => redis
 
-        @node_registry   = NodeRegistry.new(@redis)
-        @global_registry = GlobalRegistry.new(@redis)
+        @node_registry = Registry.new(@redis, 'nodes')
+        @global_registry = Registry.new(@redis, 'globals')
       end
 
-      def remove_node(node)
-        @node_registry.remove node
-      end
-
-      def clear_all_nodes
-        @node_registry.clear_all
-      end
-
-      def clear_globals
-        @global_registry.clear_all
-      end
-
-      class NodeRegistry
-        def initialize(redis)
+      class Registry
+        def initialize(redis, table)
           @redis = redis
-        end
-
-        def get(node_id)
-          @redis.hget 'nodes', node_id
-        end
-
-        def set(node_id, addr)
-          @redis.hset 'nodes', node_id, addr
-        end
-
-        def nodes
-          @redis.hkeys 'nodes'
-        end
-
-        def remove(node)
-          @redis.hdel 'nodes', node
-        end
-
-        def clear_all
-          @redis.del 'nodes'
-        end
-      end
-
-      def get_node(node_id);       @node_registry.get(node_id) end
-      def set_node(node_id, addr); @node_registry.set(node_id, addr) end
-      def nodes;                   @node_registry.nodes end
-
-      class GlobalRegistry
-        def initialize(redis)
-          @redis = redis
+          @table = table
         end
 
         def get(key)
-          string = @redis.hget 'globals', key.to_s
-          Marshal.load string if string
+          value = @redis.hget @table, key.to_s
+          value = MessagePack.unpack(value, options={:symbolize_keys => true}) if value
+          value
         end
 
-        # Set a global value
         def set(key, value)
-          string = Marshal.dump value
-          @redis.hset 'globals', key.to_s, string
+          @redis.hset @table, key.to_s, value.to_msgpack
         end
 
-        # The keys to all globals in the system
-        def global_keys
-          @redis.hkeys 'globals'
+        def all
+          @redis.hkeys @table
+        end
+
+        def remove(key)
+          @redis.hdel @table, key
         end
 
         def clear_all
-          @redis.del 'globals'
+          @redis.del @table
         end
       end
-
-      def get_global(key);        @global_registry.get(key) end
-      def set_global(key, value); @global_registry.set(key, value) end
-      def global_keys;            @global_registry.global_keys end
     end
   end
 end

--- a/lib/dcell/registries/zk_adapter.rb
+++ b/lib/dcell/registries/zk_adapter.rb
@@ -3,6 +3,9 @@ require 'zk'
 module DCell
   module Registry
     class ZkAdapter
+      include Node
+      include Global
+
       PREFIX  = "/dcell"
       DEFAULT_PORT = 2181
 
@@ -50,16 +53,20 @@ module DCell
 
         def get(key)
           result, _ = @zk.get("#{@base_path}/#{key}", watch: true)
-          Marshal.load result
+          MessagePack.unpack(result, options={:symbolize_keys => true}) if result
         rescue ZK::Exceptions::NoNode
         end
 
-        def set(key, value)
+        def _set(key, value, unique)
           path = "#{@base_path}/#{key}"
-          string = Marshal.dump value
-          @zk.set path, string
-        rescue ZK::Exceptions::NoNode
-          @zk.create path, string, :ephemeral => @ephemeral
+          @zk.create path, value.to_msgpack, :ephemeral => @ephemeral
+        rescue ZK::Exceptions::NodeExists
+          raise KeyExists if unique
+          @zk.set path, value.to_msgpack
+        end
+
+        def set(key, value)
+          _set(key, value, false)
         end
 
         def all
@@ -79,18 +86,6 @@ module DCell
           @zk.mkdir_p @base_path
         end
       end
-
-      def get_node(node_id);       @node_registry.get(node_id) end
-      def set_node(node_id, addr); @node_registry.set(node_id, addr) end
-      def nodes;                   @node_registry.all end
-      def remove_node(node_id);    @node_registry.remove(node_id) end
-      def clear_all_nodes;         @node_registry.clear_all end
-
-      def get_global(key);        @global_registry.get(key) end
-      def set_global(key, value); @global_registry.set(key, value) end
-      def global_keys;            @global_registry.all end
-      def clear_globals;          @global_registry.clear_all end
-
     end
   end
 end

--- a/lib/dcell/responses.rb
+++ b/lib/dcell/responses.rb
@@ -9,14 +9,18 @@ module DCell
 
     def to_msgpack(pk=nil)
       {
-        :type => self.class.name,
-        :args => [@request_id, @address, @value]
+        type: self.class.name,
+        args: [@request_id, @address, @value]
       }.to_msgpack(pk)
     end
 
     def dispatch
       mailbox = MailboxManager.find @address
-      mailbox << self
+      if mailbox
+        mailbox << self
+      else
+        Logger.error "Failed to find mailbox at #{@address} for #{self.class.name}"
+      end
     end
   end
 
@@ -26,9 +30,6 @@ module DCell
   # Request failed
   class ErrorResponse < Response; end
 
-  # Retry response (request to retry action)
-  class RetryResponse < Response; end
-
-  # Remote actor is dead
-  class DeadActorResponse < Response; end
+  # Internal response to cancel pending request (remote node is likely dead)
+  class CancelResponse < Response; end
 end

--- a/lib/dcell/server.rb
+++ b/lib/dcell/server.rb
@@ -41,7 +41,7 @@ module DCell
     # Decode incoming messages
     def decode_message(message)
       begin
-        msg = MessagePack.unpack(message, options={:symbolize_keys => true})
+        msg = MessagePack.unpack(message, options={symbolize_keys: true})
       rescue => ex
         raise InvalidMessageError, "couldn't unpack message: #{ex}"
       end
@@ -72,7 +72,7 @@ module DCell
     # Wait for incoming 0MQ messages
     def run
       while true
-        async.handle_message @socket.read
+        handle_message @socket.read
       end
     end
   end

--- a/lib/dcell/utils.rb
+++ b/lib/dcell/utils.rb
@@ -11,6 +11,10 @@ module DCell
         end
         obj
       end
+
+      def uuid
+        SecureRandom.uuid
+      end
     end
   end
 end

--- a/spec/dcell/actor_proxy_spec.rb
+++ b/spec/dcell/actor_proxy_spec.rb
@@ -42,6 +42,13 @@ describe DCell::ActorProxy do
     @remote_actor.future(:value).value.should == 42
   end
 
+  it "remote actor maintains context" do
+    # damn test won't work with multiple clients
+    mutable = @remote_actor.mutable
+    @remote_actor.mutable = mutable + 1
+    @remote_actor.mutable.should == mutable + 1
+  end
+
   context :linking do
     before :each do
       @local_actor = LocalActor.new

--- a/spec/dcell/dcell_spec.rb
+++ b/spec/dcell/dcell_spec.rb
@@ -1,21 +1,28 @@
 describe DCell do
   it "raises exception on unknown registry provider" do
-    expect {DCellMock.setup :registry => {:adapter => nil}}.to raise_error(ArgumentError, "no registry adapter given in config")
-    expect {DCellMock.setup :registry => {:adapter => 'invalid'}}.to raise_error(ArgumentError, "invalid registry adapter: invalid")
+    expect {DCellMock.setup}.to raise_error(ArgumentError, "no registry adapter given in config")
   end
 
   it "uses unique method of registry to generate node ID" do
-    DCellMock.setup :registry => {:adapter => 'dummy', :seed => Math::PI}
+    registry = DCell::Registry::DummyAdapter.new :seed => Math::PI
+    DCellMock.setup :registry => registry
     DCellMock.id.should == Math::PI
   end
 
   it "accepts node ID as optional setup parameter" do
-    DCellMock.setup :id => Math::E, :registry => {:adapter => 'dummy'}
+    registry = DCell::Registry::DummyAdapter.new({})
+    DCellMock.setup :id => Math::E, :registry => registry
     DCellMock.id.should == Math::E
   end
 
   it "tries to generate node ID if registry does not define :unique method and no explicit setup parameter given" do
-    DCellMock.setup :registry => {:adapter => 'noop'}
+    registry = DCell::Registry::NoopAdapter.new({})
+    DCellMock.setup :registry => registry
     DCellMock.id.should_not == nil
+  end
+
+  it "finds remote actors" do
+    actor = DCell[:test_actor].first
+    actor.value.should == 42
   end
 end

--- a/spec/dcell/directory_spec.rb
+++ b/spec/dcell/directory_spec.rb
@@ -1,20 +1,34 @@
 describe DCell::Directory do
   it "stores node addresses" do
-    DCell::Directory["foobar"] = "tcp://localhost:1870"
-    DCell::Directory["foobar"].should == "tcp://localhost:1870"
+    DCell::Directory["foobar"].address = "tcp://localhost:1870"
+    DCell::Directory["foobar"].address.should == "tcp://localhost:1870"
   end
+
+  it "stores node actors" do
+    DCell::Directory["foobar"].actors = []
+    DCell::Directory["foobar"] << :one
+    DCell::Directory["foobar"] << :two
+    DCell::Directory["foobar"].actors.should == [:one, :two]
+
+    DCell::Directory["foobar"].actors = [:three, :four]
+    DCell::Directory["foobar"].actors.should == [:three, :four]
+  end
+
   it "presents all stored addresses" do
-    DCell::Directory["foo"] = "tcp://fooaddress"
-    DCell::Directory["bar"] = "tcp://baraddress"
+    DCell::Directory["foo"].address = "tcp://fooaddress"
+    DCell::Directory["bar"].address = "tcp://baraddress"
     DCell::Directory.all.should include("foo")
     DCell::Directory.all.should include("bar")
+    DCell::Directory.map{|node| node.id}.should include("foo")
+    DCell::Directory.map{|node| node.id}.should include("bar")
   end
+
   it "clears node addresses" do
-    DCell::Directory["foo"] = "tcp://fooaddress"
-    DCell::Directory["foobar"].should == "tcp://localhost:1870"
+    DCell::Directory["foo"].address = "tcp://fooaddress"
+    DCell::Directory["foobar"].address.should == "tcp://localhost:1870"
     ["foo", "foobar"].each do |node|
       DCell::Directory.remove node
     end
-    DCell::Directory["foobar"].should_not == "tcp://localhost:1870"
+    DCell::Directory["foobar"].address.should_not == "tcp://localhost:1870"
   end
 end

--- a/spec/dcell/registries/redis_adapter_spec.rb
+++ b/spec/dcell/registries/redis_adapter_spec.rb
@@ -1,3 +1,5 @@
+require 'dcell/registries/redis_adapter'
+
 describe DCell::Registry::RedisAdapter, :pending => TEST_ADEPTER != 'redis' && "no redis" do
   subject { DCell::Registry::RedisAdapter.new TEST_DB[:redis] }
   it_behaves_like "a DCell registry"

--- a/spec/options/99-options.rb
+++ b/spec/options/99-options.rb
@@ -1,10 +1,16 @@
 def test_options
   options = {}
-  adapter = TEST_ADEPTER
-  if adapter
-    options[:registry] = {:adapter => adapter}
-    options[:registry].merge! TEST_DB[adapter.to_sym]
+  case TEST_ADEPTER
+  when 'redis'
+    registry = DCell::Registry::RedisAdapter.new TEST_DB[:redis]
+  when 'mongodb'
+    registry = DCell::Registry::MongodbAdapter.new TEST_DB[:mongodb]
+  when 'cassandra'
+    registry = DCell::Registry::CassandraAdapter.new TEST_DB[:cassandra]
+  when 'zk'
+    registry = DCell::Registry::ZkAdapter.new TEST_DB[:zk]
   end
+  options[:registry] = registry
   options['heartbeat_rate'] = 1
   options['heartbeat_timeout'] = 2
   options

--- a/spec/support/dcell_mock.rb
+++ b/spec/support/dcell_mock.rb
@@ -1,4 +1,4 @@
 module DCellMock
-  @config_lock  = Mutex.new
+  @lock  = Mutex.new
   include DCell
 end

--- a/spec/support/registry_examples.rb
+++ b/spec/support/registry_examples.rb
@@ -1,18 +1,19 @@
 shared_context "a DCell registry" do
   context "node registry" do
+    address = "tcp://localhost:7777"
+    meta = {address: address, actors: ["one", "two", "three"]}
+
     before :each do
       subject.clear_all_nodes
     end
 
-    it "stores node addresses" do
-      address = "tcp://localhost:7777"
-
-      subject.set_node("foobar", address)
-      subject.get_node("foobar").should == address
+    it "stores node address and other properties" do
+      subject.set_node("foobar", meta)
+      subject.get_node("foobar").should == meta
     end
 
     it "stores the IDs of all nodes" do
-      subject.set_node("foobar", "tcp://localhost:7777")
+      subject.set_node("foobar", meta)
       subject.nodes.should include "foobar"
     end
   end


### PR DESCRIPTION
There's a bunch of changes:
## End-user visible changes
  * clean registry API (need to update wiki once merged) - this allows easy integration of unofficial adapters
  * registry adaptors are ought to be initialized by the client and passed to DCell at setup stage
  * API to connect to an actor on different nodes(up to client how to distribute the tasks, examples updated to provide a showcase)

## Functional changes
  * optimization for async request - do not wait for the answer from the remote node
  * actor requests are handled on the behalf of the remote actor(previously on behalf of server actor) - do not affect the main process and do not affect other actors while overloading others 
  * node sends notification when it disconnects(i.e. being terminated) - speeds up disconnection process handled by hearbeat
  * if remote node is considered as dead, local client does not try to reconnect
## Misc
  * some uncrustification and refactoring

## Attention
Registry backend API has been changed and not backward compatible. From now on the node holds opaque metadata object(previously address as a string).
Also registries now use msgpack to serialize the data.